### PR TITLE
fix: get project id from pathname

### DIFF
--- a/src/lib/hash-parser-hoc.jsx
+++ b/src/lib/hash-parser-hoc.jsx
@@ -37,7 +37,7 @@ const HashParserHOC = function (WrappedComponent) {
             window.removeEventListener('hashchange', this.handleHashChange);
         }
         handleHashChange () {
-            const hashMatch = window.location.hash.match(/\/(\d+)$/);
+            const hashMatch = window.location.pathname.match(/\/(\d+)$/);
             const hashProjectId = hashMatch === null ? defaultProjectId : hashMatch[1];
             this.props.setProjectId(hashProjectId.toString());
         }


### PR DESCRIPTION
Error:
<img src="https://github.com/user-attachments/assets/7ccc9684-fab1-4099-9e89-347e0b7e01bc" width="400" />

I think this error is caused because there is no hash in the url, so I changed it to get project id from pathname