### PR TITLE
 Deployment fix: resolving customFetch error and adjusting retry logic

### DIFF
--- a/src/apis/customRequest.js
+++ b/src/apis/customRequest.js
@@ -1,0 +1,24 @@
+import xhr from 'xhr';
+
+export default function customRequest (url, method, token) {
+    const options = {
+            method: method,
+            url: url,
+            headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+        },
+    }
+    return new Promise((resolve, reject) => {
+        xhr(options, (err, response) => {
+            if (err) {
+                return reject(err);
+            }
+            if (response.statusCode !== 200 && response.statusCode !== 201) {
+                return reject(new Error(`Request failed: ${response.statusCode}`));
+            } else {
+                resolve(JSON.parse(response.body));
+            }
+        });
+    });
+};

--- a/src/containers/gui.jsx
+++ b/src/containers/gui.jsx
@@ -43,7 +43,7 @@ import cloudManagerHOC from '../lib/cloud-manager-hoc.jsx';
 import GUIComponent from '../components/gui/gui.jsx';
 import {setIsScratchDesktop} from '../lib/isScratchDesktop.js';
 import { BASE_API_URL } from '../utils/constants.js';
-import customFetch from '../apis/customFetch.js';
+import customRequest from '../apis/customRequest.js';
 import { setModalExtension } from '../reducers/modal-choose-extension.js';
 
 class GUI extends React.Component {
@@ -72,7 +72,7 @@ class GUI extends React.Component {
         }
     }
     getSpritesFromApi () {
-        this.props.onCustomFetch(`${BASE_API_URL}/md/api/sprites`, 'GET', this.props.token, this.props.onSetSession)
+        this.props.onCustomRequest(`${BASE_API_URL}/md/api/sprites`, 'GET', this.props.token)
             .then(response => {
                 this.props.onSetSprites(response);
             })
@@ -84,7 +84,7 @@ class GUI extends React.Component {
             });
     }
     getCostumesFromApi () {
-        this.props.onCustomFetch(`${BASE_API_URL}/md/api/costumes`, 'GET', this.props.token, this.props.onSetSession)
+        this.props.onCustomRequest(`${BASE_API_URL}/md/api/costumes`, 'GET', this.props.token)
             .then(response => {
                 this.props.onSetCostumes(response);
             })
@@ -96,7 +96,7 @@ class GUI extends React.Component {
             });
         }
     getSoundsFromApi () {
-        this.props.onCustomFetch(`${BASE_API_URL}/md/api/assets/sounds`, 'GET', this.props.token, this.props.onSetSession)
+        this.props.onCustomRequest(`${BASE_API_URL}/md/api/assets/sounds`, 'GET', this.props.token)
             .then(response => {
                 this.props.onSetSounds(response);
             })
@@ -138,7 +138,7 @@ class GUI extends React.Component {
             onSetSounds,
             onSetSession,
             onProjectError,
-            onCustomFetch,
+            onCustomRequest,
             projectHost,
             projectId,
             showExtension,
@@ -184,7 +184,7 @@ GUI.propTypes = {
     onSetSounds: PropTypes.func,
     onSetSession: PropTypes.func,
     onProjectError: PropTypes.func,
-    onCustomFetch: PropTypes.func.isRequired,
+    onCustomRequest: PropTypes.func.isRequired,
     projectHost: PropTypes.string,
     projectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     setModalExtensionVisibility: PropTypes.func,
@@ -200,7 +200,7 @@ GUI.defaultProps = {
     onProjectLoaded: () => {},
     onUpdateProjectId: () => {},
     onVmInit: (/* vm */) => {},
-    onCustomFetch: customFetch,
+    onCustomRequest: customRequest,
 };
 
 const mapStateToProps = state => {

--- a/src/lib/save-project-to-server.js
+++ b/src/lib/save-project-to-server.js
@@ -92,7 +92,7 @@ function refreshTokenFn (refreshToken) {
     return new Promise((resolve, reject) => {
         const options = {
             method: 'POST',
-            url: `${BASE_API_URL}/md/api/auth/refresh?userId=1`,
+            url: `${BASE_API_URL}/md/api/auth/refresh`,
             headers: {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${refreshToken}`


### PR DESCRIPTION
relates to https://github.com/orgs/MacareuxDigital/projects/11/views/1?pane=issue&itemId=98874101&issue=MacareuxDigital%7Cadventure-lab-cms%7C93

While deploying the retry fix to production, the project build failed due to a missing reference to customFetch. To resolve this, I adjusted and renamed customFetch, removing the retry logic since it’s only used for fetching assets. 
Since assets are retrieved when the page loads, they will automatically get a new token from cookies. Additionally, autosaves run every two minutes, ensuring that if the token expires, it gets updated without needing a retry mechanism.

I also removed the query parameter from the refresh API, as it was only used for testing in the local environment, where I could get a shorter token expiration time.