### PR TITLE
env/#145 change to use local API

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-PORT=8310
-NODE_ENV=development
-BASE_URL=http://127.0.0.1:8310

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 PORT=8310
 NODE_ENV=development
-BASE_URL=http://localhost:8310
+BASE_URL=http://127.0.0.1:8310

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+PORT=8310
+NODE_ENV=development
+BASE_URL=http://localhost:8310

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+NODE_ENV=local
+BASE_URL=http://127.0.0.1:8301

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ npm-*
 /build
 /dist
 /.opt-in
+.env
 
 # Generated translation files
 /translations

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
     "[json]": {
         "editor.defaultFormatter": null,
         "editor.formatOnSave": false
+    },
+    "prettier.enable": false,
+    "[javascript]": {
+        "editor.defaultFormatter": null
     }
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,17 @@
-export const BASE_API_URL = "https://chizubouken-lab.jp";
-export const TOKEN_KEY = "access_token";
-export const REFRESH_TOKEN_KEY = "refresh_token";
+/* this baseApiUrl is temporary, it should be replaced by a method using the .env file. */
+let baseApiUrl;
+
+if (process.env.NODE_ENV === 'production') {
+    // Production specific settings
+    baseApiUrl = 'https://chizubouken-lab.jp';
+} else if (process.env.NODE_ENV === 'development') {
+    // Development specific settings
+    baseApiUrl = 'https://nginx.dev.adventure-lab-cms.jp1.amazee.io/';
+} else {
+    // Local development settings
+    baseApiUrl = process.env.BASE_URL || 'http://localhost:8310';
+}
+
+export const BASE_API_URL = baseApiUrl;
+export const TOKEN_KEY = 'access_token';
+export const REFRESH_TOKEN_KEY = 'refresh_token';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,16 +1,16 @@
 /* this baseApiUrl is temporary, it should be replaced by a method using the .env file. */
 let baseApiUrl;
 
-if (process.env.NODE_ENV === 'production') {
-    // Production specific settings
-    baseApiUrl = 'https://chizubouken-lab.jp';
+if (process.env.NODE_ENV === 'development') {
+    // Local development settings
+    baseApiUrl = process.env.BASE_URL || 'http://localhost:8310';
 /* Use the following lines if we can set a different env for development and local */
 // } else if (process.env.NODE_ENV === 'development') {
 //     // Development specific settings
 //     baseApiUrl = process.env.BASE_URL || 'https://nginx.dev.adventure-lab-cms.jp1.amazee.io/';
 } else {
-    // Local development settings
-    baseApiUrl = process.env.BASE_URL || 'http://localhost:8310';
+    // Production specific settings
+    baseApiUrl = 'https://chizubouken-lab.jp';
 }
 
 export const BASE_API_URL = baseApiUrl;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,19 @@
-export const BASE_API_URL = 'https://chizubouken-lab.jp';
+/* this baseApiUrl is temporary, it should be replaced by a method using the .env file. */
+let baseApiUrl;
+
+// we need to set the specific port for local development
+if (process.env.NODE_ENV === 'local') {
+    // Local development settings
+    baseApiUrl = process.env.BASE_URL || 'http://127.0.0.1:8301';
+} else if (process.env.NODE_ENV === 'development') {
+    // Development specific settings
+    // baseApiUrl = process.env.BASE_URL || 'https://nginx.dev.adventure-lab-cms.jp1.amazee.io/'; if we want to use a specific URL for development
+    baseApiUrl = process.env.BASE_URL || '';
+} else {
+    // Production specific settings
+    baseApiUrl = 'https://chizubouken-lab.jp';
+}
+
+export const BASE_API_URL = baseApiUrl;
 export const TOKEN_KEY = 'access_token';
 export const REFRESH_TOKEN_KEY = 'refresh_token';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,9 +4,10 @@ let baseApiUrl;
 if (process.env.NODE_ENV === 'production') {
     // Production specific settings
     baseApiUrl = 'https://chizubouken-lab.jp';
-} else if (process.env.NODE_ENV === 'development') {
-    // Development specific settings
-    baseApiUrl = 'https://nginx.dev.adventure-lab-cms.jp1.amazee.io/';
+/* Use the following lines if we can set a different env for development and local */
+// } else if (process.env.NODE_ENV === 'development') {
+//     // Development specific settings
+//     baseApiUrl = process.env.BASE_URL || 'https://nginx.dev.adventure-lab-cms.jp1.amazee.io/';
 } else {
     // Local development settings
     baseApiUrl = process.env.BASE_URL || 'http://localhost:8310';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,18 +1,3 @@
-/* this baseApiUrl is temporary, it should be replaced by a method using the .env file. */
-let baseApiUrl;
-
-if (process.env.NODE_ENV === 'development') {
-    // Local development settings
-    baseApiUrl = process.env.BASE_URL || 'http://localhost:8310';
-/* Use the following lines if we can set a different env for development and local */
-// } else if (process.env.NODE_ENV === 'development') {
-//     // Development specific settings
-//     baseApiUrl = process.env.BASE_URL || 'https://nginx.dev.adventure-lab-cms.jp1.amazee.io/';
-} else {
-    // Production specific settings
-    baseApiUrl = 'https://chizubouken-lab.jp';
-}
-
-export const BASE_API_URL = baseApiUrl;
+export const BASE_API_URL = 'https://chizubouken-lab.jp';
 export const TOKEN_KEY = 'access_token';
 export const REFRESH_TOKEN_KEY = 'refresh_token';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ const base = {
     devServer: {
         contentBase: path.resolve(__dirname, 'build'),
         host: '127.0.0.1',
-        port: process.env.PORT || 8080,
+        port: process.env.PORT || 8310,
         open: true
     },
     output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ const base = {
     devServer: {
         contentBase: path.resolve(__dirname, 'build'),
         host: '127.0.0.1',
-        port: process.env.PORT || 8310,
+        port: process.env.PORT || 8301,
         open: true
     },
     output: {


### PR DESCRIPTION
### Resolves

- Resolves https://github.com/MacareuxDigital/adventure-lab-cms/issues/145

### Proposed Changes

- ENV: After the beta release, we should use the local API in local env.

### Reason for Changes

#### Try: Change to local API from productions' one

I'll note the steps I've tried.

1. As README, go to [postman collection](https://macareux-inc.postman.co/workspace/Adventure-Lab~9816a342-7a0b-40f0-b52e-63ffae6ec10c/request/36823844-e0e2c7a6-3124-44ff-aa87-22d530722843) then select "local" environment variable, and run `Token (temp)` API
2. Get messsage "Download Postman", then download and install
https://www.postman.com/downloads/
3. Try again to run `Token (temp)` API, and get the error
> Error: connect ECONNREFUSED 127.0.0.1:8301

Maybe, should we set up the local domain to `127.0.0.1:8301`?

4. Change local port 8080 to 8301 and reboot( npm start )
5. Postman's response changed like below:
```
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /md/api/auth/token</pre>
</body>
</html>
```
How does work the URL` /md/api/auth/token`?

...Maybe it's related those around codes in this repo: web/packages/md_scratch/src/Controller/API/Auth.php
So we should set up the local CMS whose theme is the repo of `adventure-lab-cms` without `web/projects` dir by `docker-compose.yml`?
And CMS's port will be also set `8301`...?

6. Anyway, access `http://127.0.0.1:8301`, then success to show the scratch with the map API!
But we have many console error like: `GET https://chizubouken-lab.jp/md/api/tag-categories 401 (Unauthorized)`
So, we should change `BASE_API_URL` to use the .env value and can switch the value by the env.

7. Change the BASE_API_URL value to use the .env file. But we have still many console errors because the local CMS is not set up now.

Next, we should set up the local CMS env.

### How to Test

1. Download [Postman](https://www.postman.com/downloads/) if you don't have yet.
2. Copy `.env.local` and rename to `.env`.
3. run 'npm start'
4. Access to [postman collection](https://macareux-inc.postman.co/workspace/Adventure-Lab~9816a342-7a0b-40f0-b52e-63ffae6ec10c/request/36823844-e0e2c7a6-3124-44ff-aa87-22d530722843) then select "local" environment variable, and run `Token (temp)` API
5. open http://127.0.0.1:8301 and check the map API can work.
6. If the scratch don't work, go to Dev tool's Application tab, and check the domain name of API keys. If it's production domain, rewrite them to 127.0.0.1. Then, reload.

![ss_2025-06-19](https://github.com/user-attachments/assets/387be4e4-db92-44e8-8a7d-4f908420a6df)

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [X] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari
